### PR TITLE
Ansible.cfg "become" revision and other misc. changes

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -8,7 +8,7 @@ interpreter_python = /usr/bin/python3
 host_key_checking = false
 
 [privilege_escalation]
-become = true
+#become = true
 become_method = sudo
 become_user = root
 become_ask_pass = false 

--- a/destroy.sh
+++ b/destroy.sh
@@ -4,7 +4,7 @@ function __usage {
 	echo
 	echo "$(basename $0) <kvm name(s)>"
 	echo "  where zero or more valid KVM names are listed as parameters"
-	echo "  if no parametrs are passed, the default list as defined"
+	echo "  if no parameters are passed, the default list as defined"
 	echo "  within the ansible playbook will be processed."
 	echo
 	exit

--- a/foreman.yml
+++ b/foreman.yml
@@ -1,7 +1,7 @@
 ---
 
-
 - name: Generate certificates for use with Foreman
+  become: true
   hosts: foreman_host
   roles:
     - rhel-system-roles.certificate
@@ -92,6 +92,9 @@
       register: fm_install_rc
 
       # HOLDING PEN FOR OTHER POSSIBLE CLI PARAMETERS
+      #    --enable-foreman-plugin-remote-execution \
+      #    --enable-foreman-proxy-plugin-remote-execution-ssh \
+      #    --foreman-proxy-plugin-remote-execution-ssh-install-key=true \
       #    --foreman-proxy-ssl=true \
       #    --foreman-proxy-ssl-ca="/etc/pki/tls/certs/ca-bundle.crt" \
       #    --foreman-proxy-ssl-cert="/etc/pki/tls/certs/{{ inventory_hostname }}.crt" \

--- a/foreman.yml
+++ b/foreman.yml
@@ -1,8 +1,8 @@
 ---
 
 - name: Generate certificates for use with Foreman
-  become: true
   hosts: foreman_host
+  become: true
   roles:
     - rhel-system-roles.certificate
   vars:

--- a/foreman_host_config.yml
+++ b/foreman_host_config.yml
@@ -8,47 +8,22 @@
 
   - name: "Create local user foreman folders"
     ansible.builtin.file:
-      path: "~/.foreman/log"
+      path: "{{ frmn_hmr_cfg_dir }}"
       recurse: true
-      owner: ansible
-      group: ansible
       mode: u+rw,g-wx,o-rwx
 
-  - name: "Create foreman.cfg"
+  - name: "Create cli_config.cfg"
     template:
-      src: foreman.cfg.j2
-      dest: ~/.foreman/foreman.cfg
-      owner: ansible
-      group: ansible
-
-  - name: "Create foreman.cfg"
-    template:
-      src: foreman.cfg.j2
-      dest: ~/.foreman/cli_config.cfg
-      owner: ansible
-      group: ansible
-
-  # - name: "Test Hammer CLI Output - ORIGINAL"
-  #   shell: |
-  #     hammer -c ~/.foreman/cli_ORIGINAL_HOST.cfg --verify-ssl false  organization list
-  #     hammer -c ~/.foreman/cli_ORIGINAL_HOST.cfg --verify-ssl false  location     list
-  #     hammer -c ~/.foreman/cli_ORIGINAL_HOST.cfg --verify-ssl false  scap-content list
-  #     hammer -c ~/.foreman/cli_ORIGINAL_HOST.cfg --verify-ssl false  policy       list
-  #     hammer -c ~/.foreman/cli_ORIGINAL_HOST.cfg --verify-ssl false  policy       info --id 1
-  #   register: hammer_out
-  #   failed_when: false
-  #   changed_when: false
-  # - name: "Hammer output"
-  #   debug:
-  #     var: hammer_out
+      src: cli_config.cfg.j2
+      dest: "{{ frmn_hmr_cfg_file }}"
 
   # - name: "Test Hammer CLI Output - NEW/SANDBOX"
   #   shell: |
-  #     hammer organization list
-  #     hammer location     list
-  #     hammer scap-content list
-  #     hammer policy       list
-  #     hammer policy       info --id 1
+  #     hammer -c "{{ frmn_hmr_cfg_file }}" organization list
+  #     hammer -c "{{ frmn_hmr_cfg_file }}" location     list
+  #     hammer -c "{{ frmn_hmr_cfg_file }}" scap-content list
+  #     hammer -c "{{ frmn_hmr_cfg_file }}" policy       list
+  #     hammer -c "{{ frmn_hmr_cfg_file }}" policy       info --id 
   #   register: hammer_out
   #   failed_when: false
   #   changed_when: false
@@ -58,7 +33,7 @@
 
   # ---------------------------------------------------------------------------
 
-  - name: "Create domain"
+  - name: "Create or update domain"
     theforeman.foreman.domain:
       name: "{{ dns_name }}"
       organizations:
@@ -72,7 +47,7 @@
       state: present
 
   # ---------------------------------------------------------------------------
-  - name: "Create lifecycle env"
+  - name: "Create or update lifecycle env"
     theforeman.foreman.lifecycle_environment:
       name: "{{ frmn_lce }}"
       label: "{{ frmn_lce | lower }}"
@@ -86,13 +61,12 @@
 
   # ---------------------------------------------------------------------------
   #  Misc. settings
-  - name: "Change Instance Title"
+  - name: "Change Settings"
     shell: |
-      hammer settings set --name instance_title --value "BeetleD - Sandbox"
-      hammer settings set --name instance_color --value "#FF5133"
-      hammer settings set --name lab_features --value true
-      hammer settings set --name remote_execution_ssh_user --value "ansible"
-      hammer settings set --name ansible_ssh_private_key_file --value "/usr/share/foreman-proxy/.ssh/id_rsa_foreman_proxy"
+      hammer -c "{{ frmn_hmr_cfg_file }}" settings set --name instance_title --value "{{ env_label }}"
+      hammer -c "{{ frmn_hmr_cfg_file }}" settings set --name instance_color --value "{{ env_colorbar }}"
+      hammer -c "{{ frmn_hmr_cfg_file }}" settings set --name remote_execution_ssh_user --value "ansible"
+      hammer -c "{{ frmn_hmr_cfg_file }}" settings set --name ansible_ssh_private_key_file --value "/usr/share/foreman-proxy/.ssh/id_rsa_foreman_proxy"
     # failed_when: false
 
   # ---------------------------------------------------------------------------
@@ -100,9 +74,9 @@
 
   # == Foreman repo related objects
 
-  - name: "Create Foreman EL 9 Client Product"
+  - name: "Create or update Foreman Product"
     theforeman.foreman.product:
-      name: "Foreman EL 9 Client Product"
+      name: "Foreman Product"
       organization: "{{ frmn_org }}"
       username: "{{ frmn_usr }}"
       password: "{{ frmn_pwd }}"
@@ -110,13 +84,13 @@
       validate_certs: "{{ frmn_validate_cert }}"
       state: present
 
-  - name: "Create Foreman repository"
+  - name: "Create or update Foreman repositories"
     theforeman.foreman.repository:
-      name: "Foreman EL 9 Client Repo"
+      name: "Foreman EL9 - {{ item }} Repo"
       content_type: "yum"
-      product: "Foreman EL 9 Client Product"
+      product: "Foreman Product"
       organization: "{{ frmn_org }}"
-      url: "http://yum.theforeman.org/client/nightly/el9/x86_64/"
+      url: "http://yum.theforeman.org/{{ item }}/el9/x86_64/"
       # mirror_on_sync: true
       mirroring_policy: mirror_content_only
       download_policy: on_demand
@@ -127,23 +101,31 @@
       server_url: "{{ frmn_url }}"
       validate_certs: "{{ frmn_validate_cert }}"
       state: present
+    with_items:
+      - client/latest
+      - releases/latest
+      - katello/4.13/katello
 
   - name: "Sync repository"
     theforeman.foreman.repository_sync:
-      repository: "Foreman EL 9 Client Repo"
-      product: "Foreman EL 9 Client Product"
+      repository: "Foreman EL9 - {{ item }} Repo"
+      product: "Foreman Product"
       organization: "{{ frmn_org }}"
       username: "{{ frmn_usr }}"
       password: "{{ frmn_pwd }}"
       validate_certs: "{{ frmn_validate_cert }}"
       server_url: "{{ frmn_url }}"
+    with_items:
+      - client/latest
+      - releases/latest
+      - katello/4.13/katello
     # when: ( run_sync | default( false ) )
 
   # == Rocky repo related objects ##
 
-  - name: "Create Rocky 9 Product"
+  - name: "Create or update Rocky 9 Product"
     theforeman.foreman.product:
-      name: "Rocky9"
+      name: "Rocky9 Product"
       organization: "{{ frmn_org }}"
       username: "{{ frmn_usr }}"
       password: "{{ frmn_pwd }}"
@@ -151,11 +133,11 @@
       validate_certs: "{{ frmn_validate_cert }}"
       state: present
 
-  - name: "Create Rocky repositories"
+  - name: "Create or update Rocky repositories"
     theforeman.foreman.repository:
       name: "Rocky 9 - {{ item }} Repo"
       content_type: "yum"
-      product: "Rocky9"
+      product: "Rocky9 Product"
       organization: "{{ frmn_org }}"
       url: "http://dl.rockylinux.org/pub/rocky/9/{{ item }}/x86_64/os/"
       # mirror_on_sync: true
@@ -176,7 +158,7 @@
   - name: "Sync repositories"
     theforeman.foreman.repository_sync:
       repository: "Rocky 9 - {{ item }} Repo"
-      product: "Rocky9"
+      product: "Rocky9 Product"
       organization: "{{ frmn_org }}"
       username: "{{ frmn_usr }}"
       password: "{{ frmn_pwd }}"
@@ -188,16 +170,59 @@
       - extras
     # when: ( run_sync | default( false ) )
 
-  - name: "Create or update weekly Foreman/Rocky sync plan"
-    theforeman.foreman.sync_plan:
-      name: "Weekly Foreman/Rocky Sync"
+  # == EPEL repo related objects
+
+  - name: "Create or update EPEL Product"
+    theforeman.foreman.product:
+      name: "EPEL Product"
       organization: "{{ frmn_org }}"
-      interval: "weekly"
+      username: "{{ frmn_usr }}"
+      password: "{{ frmn_pwd }}"
+      server_url: "{{ frmn_url }}"
+      validate_certs: "{{ frmn_validate_cert }}"
+      state: present
+
+  - name: "Create or update EPEL repository"
+    theforeman.foreman.repository:
+      name: "EPEL9 Repo"
+      content_type: "yum"
+      product: "EPEL Product"
+      organization: "{{ frmn_org }}"
+      url: "https://dl.fedoraproject.org/pub/epel/9/Everything/x86_64/"
+      # mirror_on_sync: true
+      mirroring_policy: mirror_content_only
+      download_policy: on_demand
+      os_versions: []
+      arch: "x86_64"
+      username: "{{ frmn_usr }}"
+      password: "{{ frmn_pwd }}"
+      server_url: "{{ frmn_url }}"
+      validate_certs: "{{ frmn_validate_cert }}"
+      state: present
+
+  - name: "Sync repository"
+    theforeman.foreman.repository_sync:
+      repository: "EPEL9 Repo"
+      product: "EPEL Product"
+      organization: "{{ frmn_org }}"
+      username: "{{ frmn_usr }}"
+      password: "{{ frmn_pwd }}"
+      validate_certs: "{{ frmn_validate_cert }}"
+      server_url: "{{ frmn_url }}"
+    # when: ( run_sync | default( false ) )
+
+  # == Sync related objects ##
+  - name: "Create or update sync plan"
+    theforeman.foreman.sync_plan:
+      name: "{{ frmn_gen_name }} Sync Plan"
+      organization: "{{ frmn_org }}"
+      interval: "daily"
       enabled: true
       sync_date: "2024-06-01 00:00:00 UTC"
       products:
-        - 'Rocky9'
-        - 'Foreman EL 9 Client Product'
+        - 'Rocky9 Product'
+        - 'Foreman Product'
+        # - 'EPEL Product'
       username: "{{ frmn_usr }}"
       password: "{{ frmn_pwd }}"
       server_url: "{{ frmn_url }}"
@@ -206,15 +231,18 @@
 
   # ---------------------------------------------------------------------------
 
-  - name: "Create content view"
+  - name: "Create or update content view"
     theforeman.foreman.content_view:
       name: "APE Content View"
       organization: "{{ frmn_org }}"
       repositories:
-        - { name: "Foreman EL 9 Client Repo", product: "Foreman EL 9 Client Product" }
-        - { name: "Rocky 9 - BaseOS Repo",    product: "Rocky9" }
-        - { name: "Rocky 9 - AppStream Repo", product: "Rocky9" }
-        - { name: "Rocky 9 - extras Repo",    product: "Rocky9" }
+        - { name: "Foreman EL9 - client/latest Repo",        product: "Foreman Product" }
+        - { name: "Foreman EL9 - releases/latest Repo",      product: "Foreman Product" }
+        - { name: "Foreman EL9 - katello/4.13/katello Repo", product: "Foreman Product" }
+        - { name: "Rocky 9 - BaseOS Repo",    product: "Rocky9 Product" }
+        - { name: "Rocky 9 - AppStream Repo", product: "Rocky9 Product" }
+        - { name: "Rocky 9 - extras Repo",    product: "Rocky9 Product" }
+        # - { name: "EPEL Repo",    product: "EPEL Product" }
       solve_dependencies: true
       username: "{{ frmn_usr }}"
       password: "{{ frmn_pwd }}"
@@ -238,17 +266,20 @@
 
   # ---------------------------------------------------------------------------
 
-  - name: "Create client activation key"
+  - name: "Create or update client activation key"
     theforeman.foreman.activation_key:
       name: "{{ frmn_act_key }}"
       organization: "{{ frmn_org }}"
       lifecycle_environment: "{{ frmn_lce }}"
       content_view: "APE Content View"
       content_overrides:
-        - { label: "Default_Organization_Foreman_EL_9_Client_Product_Foreman_EL_9_Client_Repo", override: enabled }
-        - { label: "Default_Organization_Rocky9_Rocky_9_-_BaseOS_Repo",                         override: enabled }
-        - { label: "Default_Organization_Rocky9_Rocky_9_-_AppStream_Repo",                      override: enabled }
-        - { label: "Default_Organization_Rocky9_Rocky_9_-_extras_Repo",                         override: enabled }
+        - { label: "Default_Organization_Rocky9_Product_Rocky_9_-_BaseOS_Repo",                    override: enabled }
+        - { label: "Default_Organization_Rocky9_Product_Rocky_9_-_AppStream_Repo",                 override: enabled }
+        - { label: "Default_Organization_Rocky9_Product_Rocky_9_-_extras_Repo",                    override: enabled }
+        - { label: "Default_Organization_Foreman_Product_Foreman_EL9_-_client_latest_Repo",        override: enabled }
+        - { label: "Default_Organization_Foreman_Product_Foreman_EL9_-_katello_4_13_katello_Repo", override: enabled }
+        - { label: "Default_Organization_Foreman_Product_Foreman_EL9_-_releases_latest_Repo",      override: enabled }
+        - { label: "Default_Organization_EPEL_Product_EPEL9_Repo",                                 override: enabled }
       username: "{{ frmn_usr }}"
       password: "{{ frmn_pwd }}"
       server_url: "{{ frmn_url }}"
@@ -257,7 +288,7 @@
 
   # ---------------------------------------------------------------------------
 
-  - name: "Create APE hostgroup"
+  - name: "Create or update APE hostgroup"
     theforeman.foreman.hostgroup:
       name: "{{ frmn_hostgroup_name }}"
       organization: "{{ frmn_org }}"
@@ -279,7 +310,7 @@
 
   - name: "Bulk upload OpenSCAP content"
     shell: |
-      hammer scap-content bulk-upload --type 'directory' --directory /usr/share/xml/scap/ssg/content --organization "{{ frmn_org }}" --location "{{ frmn_loc }}"
+      hammer -c "{{ frmn_hmr_cfg_file }}" scap-content bulk-upload --type 'directory' --directory /usr/share/xml/scap/ssg/content --organization "{{ frmn_org }}" --location "{{ frmn_loc }}"
     register: hammer_out
     failed_when: 
       - ( hammer_out.rc != 0 )
@@ -288,7 +319,7 @@
   # ---------------------------------------------------------------------------
   - name: "Query for policy"
     shell: |
-      hammer --output json policy info --name '{{ dns_name }} Policy' | jq '.Id'
+      hammer -c "{{ frmn_hmr_cfg_file }}" --output json policy info --name '{{ frmn_gen_name }} Policy' | jq '.Id'
     register: hammer_qry
     failed_when: false
   - name: "Set frmn_policy_exists fact"
@@ -297,7 +328,7 @@
 
   - name: "Create policy"
     shell: |
-      hammer policy create --name "{{ dns_name }} Policy" --description "Created via Ansible playbook" --organization "{{ frmn_org }}" --location "{{ frmn_loc }}" --hostgroups "{{ frmn_hostgroup_name }}" --period weekly --weekday sunday --scap-content "rl9 content" --scap-content-profile-id 37  --deploy-by ansible
+      hammer -c "{{ frmn_hmr_cfg_file }}" policy create --name "{{ frmn_gen_name }} Policy" --description "Created via Ansible playbook" --organization "{{ frmn_org }}" --location "{{ frmn_loc }}" --hostgroups "{{ frmn_hostgroup_name }}" --period weekly --weekday sunday --scap-content "rl9 content" --scap-content-profile-id 37  --deploy-by ansible
     when: ( frmn_policy_exists == false )
     register: hammer_out
     failed_when: 
@@ -307,7 +338,7 @@
 
   - name: "Update policy"
     shell: |
-      hammer policy update --name "{{ dns_name }} Policy" --description "Created via Ansible playbook" --organization "{{ frmn_org }}" --location "{{ frmn_loc }}" --hostgroups "{{ frmn_hostgroup_name }}" --period weekly --weekday sunday --scap-content "rl9 content" --scap-content-profile-id 37  --deploy-by ansible
+      hammer -c "{{ frmn_hmr_cfg_file }}" policy update --name "{{ frmn_gen_name }} Policy" --description "Created via Ansible playbook" --organization "{{ frmn_org }}" --location "{{ frmn_loc }}" --hostgroups "{{ frmn_hostgroup_name }}" --period weekly --weekday sunday --scap-content "rl9 content" --scap-content-profile-id 37  --deploy-by ansible
     when: ( frmn_policy_exists == true )
     register: hammer_out
     failed_when: 
@@ -315,18 +346,4 @@
       - ( hammer_out.rc != 65 )
       - '"Name has already been taken" not in hammer_out.stdout'
 
-  # ---------------------------------------------------------------------------
-  #  When using the "generate-command", it would be used for any previously
-  #    un-registered host
-  - name: "Generate host-registration command"
-    shell: |
-      hammer host-registration generate-command --activation-keys "{{ frmn_act_key }}"
-    register: hammer_out
-  - name: "Set frmn_reg_cmd fact"
-    set_fact:
-      frmn_reg_cmd: "{{ hammer_out.stdout }}"
-
-  - name: "Generated registration command"
-    debug:
-      var: frmn_reg_cmd
   # ---------------------------------------------------------------------------

--- a/hosts/ivlab.yml
+++ b/hosts/ivlab.yml
@@ -1,4 +1,4 @@
-# file: inventories/ivlab.yml
+# file: hosts/ivlab.yml
 
 tang_host:
 
@@ -29,6 +29,8 @@ all:
     ansible_python_interpreter: /usr/bin/python3
     ansible_ssh_common_args: '-o StrictHostKeyChecking=no'
     dns_name: 'ape.test'
+    env_label: 'Unclassified'
+    env_colorbar: '#067040'
     kvm_list:
       - {name: "ipa1",       ip_addr: "192.168.100.40", enabled: true,  roles: ["ipa_host",      "nbde_clients", "logger_client"], cpus: 2, ram_mb: 4096}
       - {name: "tang",       ip_addr: "192.168.100.41", enabled: true,  roles: ["tang_host",     "nbde_servers", "ipa_client", "logger_client"], ram_mb: 3072}

--- a/ipa.yml
+++ b/ipa.yml
@@ -26,6 +26,7 @@
   roles:
   - role: ipaserver
     state: present
+  tags: ipa_cfg_server
 
 - name: Playbook to configure IPA clients
   hosts: ipa_client
@@ -33,3 +34,4 @@
   roles:
   - role: ipaclient
     state: present
+  tags: ipa_cfg_client

--- a/kvm_gen_post.yml
+++ b/kvm_gen_post.yml
@@ -6,6 +6,17 @@
     - name: "Include task list for Foreman Host/Master config"
       include_tasks: foreman_host_config.yml
 
+    # ---------------------------------------------------------------------------
+    #  When using the "generate-command", it would be used for any previously
+    #    un-registered host
+    - name: "Generate host-registration command"
+      shell: |
+        hammer -c "{{ frmn_hmr_cfg_file }}" host-registration generate-command --activation-keys "{{ frmn_act_key }}"
+      register: frmn_reg_cmd
+    - name: "Save host-registration command"
+      set_fact:
+        reg_cmd: "{{ frmn_reg_cmd.stdout }}" 
+
 # --------------------------------------------------------------------------------------------------
 
 - hosts: kvms
@@ -37,41 +48,6 @@
     #     var: frmn_gen_name
 
     # ---------------------------------------------------------------------------
-    - name: "Query for Host"
-      shell: |
-        hammer --output json host info --name '{{ inventory_hostname }}.{{ dns_name }}' | jq '.Id'
-      register: hammer_qry
-      failed_when: false
-      changed_when: false
-    - name: "Set frmn_host_exists fact"
-      set_fact:
-        frmn_host_exists: "{% if ( hammer_qry.rc != 0 ) or ( hammer_qry.stdout == '' ) %}false{% else %}true{% endif %}"
-
-    # - name: "Create host"
-    #   shell: |
-    #     hammer host create --name "{{ dns_name }} Policy" --description "Created via Ansible playbook" --organization "{{ frmn_org }}" --location "{{ frmn_loc }}" --hostgroups "{{ frmn_hostgroup_name }}" --period weekly --weekday sunday --scap-content "rl9 content" --scap-content-profile-id 37  --deploy-by ansible
-    #   when: ( frmn_host_exists == false )
-    #   register: hammer_out
-    #   failed_when: 
-    #     - ( hammer_out.rc != 0 )
-    #     - ( hammer_out.rc != 65 )
-    #     - '"Name has already been taken" not in hammer_out.stdout'
-
-    - name: "Update host"
-      shell: |
-        hammer host update --name "{{ inventory_hostname }}.{{ dns_name }}" --organization "{{ frmn_org }}" --location "{{ frmn_loc }}" --hostgroup "{{ frmn_hostgroup_name }}"
-      # --comment="Updated (UTC): {{ now(utc=true,fmt='%Y-%m-%d %H:%M:%S') }}"
-      when: ( frmn_host_exists == true )
-      register: hammer_out
-      failed_when: 
-        - ( hammer_out.rc != 0 )
-        - ( hammer_out.rc != 65 )
-        - '"Name has already been taken" not in hammer_out.stdout'
-      changed_when: '"Host updated" in hammer_out.stdout'
-    # - name: "Debug 'frmn_host_exists'"
-    #   debug:
-    #     var: hammer_out
-
     ##### Appears that "registration_command" module is part of v4.1.0-dev of Foreman Ansible stuff
     #####   and not available to us with 3.11
     # - name: "Generate registration command"
@@ -86,11 +62,19 @@
     #   debug:
     #     var: command
 
-    # - name: "Perform registration"
-    #   ansible.builtin.shell:
-    #     cmd: "{{ command.registration_command }}"
+    - name: "Perform registration"
+      become: true
+      ansible.builtin.shell:
+        cmd: "{{ hostvars[groups['foreman_host'][0]].reg_cmd }}"
+      register: reg_out
+      failed_when: 
+        - ( reg_out.rc != 0 )
+        - ( reg_out.rc != 1 )
+        - '"This system is already reigstered" not in reg_out.stdout'
+      # when: ( frmn_reg_cmd is defined )
 
     - name: "Disable list of internet-accessed repositories"
+      become: true
       community.general.dnf_config_manager:
         name:
           - appstream
@@ -101,4 +85,25 @@
     ## ----------------------------------------------------------- ##
     ## 
     ## ----------------------------------------------------------- ##
+
+- hosts: foreman_host
+  gather_facts: false
+
+  tasks:
+
+    # ---------------------------------------------------------------------------
+    #  Force update to hostgroup for all hosts that should now exist based
+    #    on "registration" above
+    - name: "Ensure hostgroup membership"
+      shell: |
+        hammer -c "{{ frmn_hmr_cfg_file }}" host update --name "{{ item }}.{{ dns_name }}" --organization "{{ frmn_org }}" --location "{{ frmn_loc }}" --hostgroup "{{ frmn_hostgroup_name }}"
+      register: hammer_out
+      failed_when: 
+        - ( hammer_out.rc != 0 )
+        - ( hammer_out.rc != 65 )
+      changed_when: '"Host updated" in hammer_out.stdout'
+      with_items:
+        - '{{ kvm_list | selectattr("enabled") | map(attribute="name") }}'
+
+# --------------------------------------------------------------------------------------------------
 

--- a/kvm_provision.yml
+++ b/kvm_provision.yml
@@ -57,6 +57,7 @@
     - nbde_cfg
 
 - name: Include a play for IPA Server/Client
+  become: true
   ansible.builtin.import_playbook: ipa.yml
   tags:
     - ipa_cfg

--- a/logging.yml
+++ b/logging.yml
@@ -1,7 +1,7 @@
 ---
 - name: Configure firewalld or syslog server
-  become: true
   hosts: logger_host
+  become: true
   tasks:
     - name: Allow incoming syslog traffic to the local host
       ansible.builtin.include_role:
@@ -16,6 +16,7 @@
 
 - name: Configure syslog server to receive remote log messages and store them locally
   hosts: logger_host
+  become: true
   roles:
     - rhel-system-roles.logging
   vars:
@@ -50,6 +51,7 @@
 # Client Configuration
 - name: Configure syslog client to send to logger server
   hosts: logger_client
+  become: true
   roles:
     - rhel-system-roles.logging
   vars:

--- a/logging.yml
+++ b/logging.yml
@@ -1,5 +1,6 @@
 ---
 - name: Configure firewalld or syslog server
+  become: true
   hosts: logger_host
   tasks:
     - name: Allow incoming syslog traffic to the local host

--- a/nbde.yml
+++ b/nbde.yml
@@ -1,14 +1,17 @@
 - name: Open firewall for Tang
   hosts: nbde_servers
+  become: true
   roles:
     - rhel-system-roles.firewall
 
 - name: Deploy NBDE Tang server
   hosts: nbde_servers
+  become: true
   roles:
     - rhel-system-roles.nbde_server
 
 - name: Deploy NBDE Clevis clients
   hosts: nbde_clients
+  become: true
   roles:
     - rhel-system-roles.nbde_client

--- a/registry.yml
+++ b/registry.yml
@@ -1,5 +1,7 @@
 ---
+
 - name: Generate certificates for use with Quay mirror registry
+  become: true
   hosts: registry_host
   roles:
     - rhel-system-roles.certificate
@@ -11,6 +13,7 @@
         ca: ipa
 
 - name: Configure firewalld for access to mirror registry
+  become: true
   hosts: registry_host
   tasks:
     - name: Allow incoming API traffic to the local host and then to pod

--- a/registry.yml
+++ b/registry.yml
@@ -1,8 +1,8 @@
 ---
 
 - name: Generate certificates for use with Quay mirror registry
-  become: true
   hosts: registry_host
+  become: true
   roles:
     - rhel-system-roles.certificate
   vars:
@@ -13,8 +13,8 @@
         ca: ipa
 
 - name: Configure firewalld for access to mirror registry
-  become: true
   hosts: registry_host
+  become: true
   tasks:
     - name: Allow incoming API traffic to the local host and then to pod
       ansible.builtin.include_role:

--- a/templates/cli_config.cfg.j2
+++ b/templates/cli_config.cfg.j2
@@ -6,5 +6,5 @@
   :username: '{{ vault_foreman_admin_usr  }}'
   :password: '{{ vault_foreman_admin_pwd  }}'
 
-:log_dir: '~/.foreman.log'
-:log_level: 'debug'
+:log_dir: '{{ frmn_hmr_log_dir }}'
+:log_level: '{{ frmn_hmr_log_lvl }}'

--- a/vars/frmn.yml
+++ b/vars/frmn.yml
@@ -11,3 +11,7 @@ frmn_pwd: "{{ vault_foreman_admin_pwd }}"
 frmn_repo_list: []
 frmn_content_obj_list: []
 frmn_validate_cert: false
+frmn_hmr_cfg_dir: "~/.foreman"
+frmn_hmr_cfg_file: "{{ frmn_hmr_cfg_dir }}/cli_config.cfg"
+frmn_hmr_log_dir: "{{ frmn_hmr_cfg_dir }}/log"
+frmn_hmr_log_lvl: "debug"

--- a/vault.yml
+++ b/vault.yml
@@ -1,8 +1,8 @@
 ---
 
 - name: Generate certificates for use with Hashicorp Vault
-  become: true
   hosts: vault_host
+  become: true
   roles:
     - rhel-system-roles.certificate
   vars:
@@ -13,8 +13,8 @@
         ca: ipa
 
 - name: Configure firewall, folders, config files, etc. for Hashicorp Vault
-  become: true
   hosts: vault_host
+  become: true
   tasks:
     - name: Allow incoming traffic to the local host
       ansible.builtin.include_role:

--- a/vault.yml
+++ b/vault.yml
@@ -1,5 +1,7 @@
 ---
+
 - name: Generate certificates for use with Hashicorp Vault
+  become: true
   hosts: vault_host
   roles:
     - rhel-system-roles.certificate
@@ -11,6 +13,7 @@
         ca: ipa
 
 - name: Configure firewall, folders, config files, etc. for Hashicorp Vault
+  become: true
   hosts: vault_host
   tasks:
     - name: Allow incoming traffic to the local host


### PR DESCRIPTION
High-level revisions:

- _ansible.cfg_ revised such that "become = true" commented out
- where necessary (due to _ansible.cfg_ change) "become" directives added
- down to single "hammer" related configuration file which is "variablized" and use throughout all CLI task calls
- standardized/simplified all Foreman object names in support of 3 product and associated repositories
- host/KVM registration included for all enabled hosts

_Notes:_
- Manual execution to import Ansible roles still required after Foreman software installed; otherwise, items in "foreman_host_config.yml" will fail
- "mirror-reg" related software deployment still gets stuck with task for "Ensure certificate requests" task.  Appears to ONLY occur during subsequent (not INITIAL) task execution.