### PR TITLE
Revisions for week ending 2024.06.21

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -26,11 +26,11 @@ Upon launching "./setup.sh", user will be prompted for multiple passwords includ
 The following items have been configured for deployment to the KVM instances based on the specified "role":
 
 - [x] FreeIPA (role: ipa_host / ipa_client) - Identity Management System providing Identity, Policy, and Audit (IPA) capabilities.
-- [x] Quay Mirror Registr (role: registry_host)
-- [ ] Foreman with Katello (role: foreman_host)
-- [ ] Tang (role: nbde_servers) and Clevis (role: nbde_clients) - Disk encryption via LUKS with centralized key repository - TBD
-- [ ] Vault (role: vault_host) - HashiCorp - TBD
-- [ ] E-mail Relay
+- [x] Quay Mirror Registry (role: registry_host)
+- [x] Foreman with Katello (role: foreman_host)
+- [*] Tang (role: nbde_servers) and Clevis (role: nbde_clients) - Disk encryption via LUKS with centralized key repository - TBD
+- [*] Vault (role: vault_host) - HashiCorp (role: vault_host)
+- [*] E-mail Relay
 - [ ] ClamAV
 - [ ] Backup Server
 - [ ] CI/CD Tooling

--- a/foreman_host_config.yml
+++ b/foreman_host_config.yml
@@ -222,7 +222,7 @@
       products:
         - 'Rocky9 Product'
         - 'Foreman Product'
-        # - 'EPEL Product'
+        - 'EPEL Product'
       username: "{{ frmn_usr }}"
       password: "{{ frmn_pwd }}"
       server_url: "{{ frmn_url }}"

--- a/group_vars/registry_host
+++ b/group_vars/registry_host
@@ -6,4 +6,5 @@ ansible_become_user: root
 ansible_become_password: "{{ vault_kvm_os_usr_ans_pwd }}"
 ansible_ssh_private_key_file: "{{ vault_kvm_os_usr_ans_keyfile }}"
 
+quay_admin_user: "admin"
 quay_admin_password: "{{ vault_quay_admin_pwd }}"

--- a/group_vars/vault_host
+++ b/group_vars/vault_host
@@ -5,3 +5,7 @@ ansible_ssh_user: ansible
 ansible_become_user: root
 ansible_become_password: "{{ vault_kvm_os_usr_ans_pwd }}"
 ansible_ssh_private_key_file: "{{ vault_kvm_os_usr_ans_keyfile }}"
+
+quay_url_fqdn: "mirror-reg.{{ dns_name }}:8443"
+quay_admin_user: "admin"
+quay_admin_password: "{{ vault_quay_admin_pwd }}"

--- a/kvm_provision.yml
+++ b/kvm_provision.yml
@@ -90,6 +90,12 @@
   tags:
     - logger_cfg
 
+- name: Include "miscellaneous" tasks
+  ansible.builtin.import_playbook: misc.yml
+  tags:
+    - misc_cfg
+    - kvm_post_cfg
+
 - name: Include a play for generic KVM "POST" configuration
   ansible.builtin.import_playbook: kvm_gen_post.yml
   tags:

--- a/misc.yml
+++ b/misc.yml
@@ -1,0 +1,14 @@
+---
+- name: Deploy postfix
+  hosts: logger_host
+  become: true
+  tasks:
+    - name: "Include rhel-system-roles.postfix"
+      ansible.builtin.include_role:
+        name: rhel-system-roles.postfix
+      vars:
+        postfix_conf:
+          relay_domains: $mydestination
+          relayhost: "{{ dns_name }}"
+        postfix_manage_firewall: true
+        # postfix_manage_selinux: true

--- a/registry.yml
+++ b/registry.yml
@@ -53,7 +53,7 @@
         cd /srv/quay_install &&
         ./mirror-registry install --quayHostname "{{ inventory_hostname }}.{{ dns_name }}" \
                                   --quayRoot /opt/quay \
-                                  --initUser admin \
+                                  --initUser {{ quay_admin_user }} \
                                   --initPassword {{ quay_admin_password }} \
                                   --sslCert "/etc/pki/tls/certs/{{ inventory_hostname }}.crt" \
                                   --sslKey "/etc/pki/tls/private/{{ inventory_hostname }}.key" \

--- a/templates/vault-pod.service.j2
+++ b/templates/vault-pod.service.j2
@@ -1,0 +1,51 @@
+[Unit]
+Description=Vault Container
+Documentation=https://www.vaultproject.io/docs/
+Wants=network.target
+After=network-online.target
+#Before=
+#ConditionFileNotEmpty=/opt/vault/config/config.hcl
+StartLimitIntervalSec=120
+StartLimitBurst=5
+
+[Service]
+WorkingDirectory=/opt/vault
+#User=vault
+#Group=vault
+#Capabilities=CAP_IPC_LOCK+ep
+#CapabilityBoundingSet=CAP_SYSLOG CAP_IPC_LOCK
+LimitMEMLOCK=infinity
+Type=forking
+RemainAfterExit=yes
+TimeoutStartSec=5m
+#ExecStartPre=-/bin/rm -f %V/%n-pid %V/%n-cid
+ExecStart=/usr/bin/podman run \
+    -d \
+    --log-level debug \
+    --cap-add=IPC_LOCK \
+    -v "/opt/vault:/vault:Z" \
+    --userns=keep-id \
+    -e 'SKIP_CHOWN=true' \
+    -e 'SKIP_SETCAP=true' \
+    -p 8200:8200/tcp \
+    vault vault server --config=/vault/config/
+
+#    --cgroups=no-conmon \
+#    --conmon-pidfile %V/%n-pid \
+#    --cidfile %V/%n-cid \
+#    --name vault \
+#    --replace \
+#       {{ quay_url_fqdn }}/hashicorp/vault:latest
+
+#ExecStop=/usr/bin/podman stop --ignore --cidfile %V/%n-cid -t 10
+ExecStop=/usr/bin/podman stop --all -t 10
+#ExecStopPost=/usr/bin/podman rm --ignore -f --cidfile %V/%n-cid
+ExecStopPost=/usr/bin/podman rm --all
+#PIDFile=%V/%n-pid
+KillMode=none
+Restart=always
+RestartSec=30
+
+[Install]
+WantedBy=multi-user.target
+#WantedBy=multi-user.target default.target

--- a/templates/vault.hcl.j2
+++ b/templates/vault.hcl.j2
@@ -2,16 +2,21 @@ ui            = true
 cluster_addr  = "https://127.0.0.1:8201"
 api_addr      = "https://127.0.0.1:8200"
 disable_mlock = true
-storage "raft" {
-  path = "/opt/vault/raft/data"
-  node_id = "raft_node_id"
+storage "file" {
+  path = "/vault/file"
 }
+#storage "raft" {
+#  path = "/vault/raft/data"
+#  node_id = "raft_node_id"
+#}
 listener "tcp" {
-  address       = "{{ ansible_default_ipv4.address }}:8200"
-  tls_cert_file = "/etc/pki/tls/certs/{{ inventory_hostname }}.crt"
-  tls_key_file  = "/etc/pki/tls/private/{{ inventory_hostname }}.key"
+  address             = "0.0.0.0:8200"
+  #address             = "{{ ansible_default_ipv4.address }}:8200"
+  tls_cert_file       = "/vault/tls/vault-cert.pem"
+  tls_key_file        = "/vault/tls/vault-key.pem"
+  tls_client_ca_file  = "/vault/tls/vault-ca.pem"
 }
-telemetry {
-  statsite_address = "127.0.0.1:8125"
-  disable_hostname = true
-}
+#telemetry {
+#  statsite_address = "127.0.0.1:8125"
+#  disable_hostname = true
+#}

--- a/vault.yml
+++ b/vault.yml
@@ -21,45 +21,104 @@
         name: rhel-system-roles.firewall
       vars:
         firewall:
-          - {zone: public,
-             service: [http, https],
-             port: [ '8200/tcp', '8201/tcp', '9090/tcp' ],
-             state: enabled}
-    - name: Create target folder for software upload
-      ansible.builtin.file:
-        path: /srv/vault_install
-        state: directory
-        owner: ansible
-        mode: '0755'
-    ## Start - Temporary tasks because extracted files are supposed to go /usr/local/bin (per existing playbook)
-    ##  
+          - {zone: public, port: [ '8200/tcp', '8201/tcp' ], state: enabled}
+    - name: Install podman
+      ansible.builtin.package:
+        name: podman
+        state: present
+    - name: Create/update vault user
+      ansible.builtin.user:
+        name: vault
+        comment: 'Hashicorp Vault - Created via ansible'
+        uid: 1010
+        shell: /bin/bash
+        state: present
     - name: Create target vault configuration files
       ansible.builtin.file:
-        path: /opt/vault
+        path: "{{ item }}"
         state: directory
-        owner: ansible
+        # owner: vault
+        # group: vault
         mode: '0755'
-    - name: Create folder for Raft data storage
-      ansible.builtin.file:
-        path: /opt/vault/raft/data
-        state: directory
-        owner: ansible
-        mode: '0755'
-    - name: Stage 'vault' archive on target for later execution
-      become: false
-      ansible.builtin.unarchive:
-        src: /srv/software/vault_1.16.3+ent.fips1402_linux_amd64.zip
-        dest: /opt/vault
-    - name: Stage 'vault' configuration file
-      become: false
-      template:
+      with_items:
+        - /opt/vault
+        - /opt/vault/logs
+        - /opt/vault/file
+        - /opt/vault/config
+        - /opt/vault/tls
+        # - /opt/vault/raft
+        # - /opt/vault/raft/data
+    - name: Copy CA cert file to vault/tls folder
+      ansible.builtin.copy:
+        src: /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
+        dest: /opt/vault/tls/vault-ca.pem
+        # owner: vault
+        # group: vault
+        mode: '0644'
+        remote_src: yes
+    - name: Copy server cert to vault/tls folder
+      ansible.builtin.copy:
+        src: /etc/pki/tls/certs/{{ inventory_hostname }}.crt
+        dest: /opt/vault/tls/vault-cert.pem
+        # owner: vault
+        # group: vault
+        mode: '0644'
+        remote_src: yes
+    - name: Copy server private key to vault/tls folder
+      ansible.builtin.copy:
+        src: /etc/pki/tls/private/{{ inventory_hostname }}.key
+        dest: /opt/vault/tls/vault-key.pem
+        # owner: vault
+        # group: vault
+        mode: '0640'
+        remote_src: yes
+    - name: Copy vault configuration file
+      ansible.builtin.template: 
         src: vault.hcl.j2
-        dest: /opt/vault/vault.hcl
-        owner: ansible
-        group: ansible
-    - name: Set vault binary capabilities
-      capabilities:
-        path: /opt/vault/vault
-        capability: cap_ipc_lock+ep
-        state: present
-    ## End - Temporary tasks because extracted files are supposed to go /usr/local/bin (per existing playbook)
+        dest: /opt/vault/config/config.hcl
+        # owner: vault
+        # group: vault
+        mode: 0640
+
+- name: Prepare podman image/container for execution 
+  hosts: vault_host
+  # become_user: vault
+  become: true
+  tasks:
+    - name: Login to APE container registry
+      containers.podman.podman_login:
+        username: '{{ quay_admin_user }}'
+        password: '{{ quay_admin_password }}'
+        registry: mirror-reg.ape.test:8443
+        tlsverify: true
+    - name: Pull Hashicorp Vault container from APE container registry
+      containers.podman.podman_image:
+        name: mirror-reg.ape.test:8443/hashicorp/vault
+        tag: latest
+        # username: '{{ quay_admin_user }}'
+        # password: '{{ quay_admin_password }}'
+        validate_certs: true
+
+- name: Configure systemd service for Hashicorp Vault container
+  hosts: vault_host
+  become: true
+  tasks:
+    - name: Force systemd to re-read configs
+      ansible.builtin.systemd_service:
+        daemon_reload: true
+    - name: Stage systemd service file for container
+      ansible.builtin.template:
+        src: vault-pod.service.j2
+        dest: /etc/systemd/system/vault-pod.service
+        mode: 0644
+      register: svc_cfg_file
+    - name: Set state of vault container service
+      ansible.builtin.systemd_service:
+        name: vault-pod
+        state: started
+        enabled: true
+      register: svc_cfg_stat
+    - name: If svc changed, force systemd to restart
+      ansible.builtin.systemd_service:
+        daemon_reexec: true
+      when: svc_cfg_file is changed or svc_cfg_stat is changed


### PR DESCRIPTION
Changes include:
- Remainder of changes related to 'ansible.cfg' change to "become"
- Inclusion of "EPEL" repository config within Foreman
- Introduction of "postfix" on _logger_ KVM for email relay
- Deployment of HashiCorp Vault container, associated configuration, and systemd handling of same
- README.MD updates to reflect current state